### PR TITLE
change volume pathing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       container_name: arches_db
       image: kartoza/postgis:12.0
       volumes:
-          - postgres-data:/var/lib/postgresql/data
+          - postgres-data:/var/lib/postgresql
           - postgres-log:/var/log/postgresql
           - ./docker/init-unix.sql:/docker-entrypoint-initdb.d/init.sql # to set up the DB template
       ports:


### PR DESCRIPTION
The pathing for the postgres container data directory is incorrect - causes data to be ephemeral.  This change will cause it to write the data to the volume.